### PR TITLE
Make role view admin-only, event posts into a wall announce, and impr…

### DIFF
--- a/plugins/events/helpers.rb
+++ b/plugins/events/helpers.rb
@@ -74,7 +74,8 @@ module AresMUSH
       character: enactor,
       content_warning: warning)
         
-      Channels.announce_notification(t('events.event_created_notification', :title => title))
+      # Channels.announce_notification(t('events.event_created_notification', :title => title, :name => enactor.name))
+      Manage.announce t('events.event_created_notification', :title => title, :name => enactor.name)
       Events.events_updated
       Achievements.award_achievement(enactor, "event_created")
       return event

--- a/plugins/events/locales/locale_en.yml
+++ b/plugins/events/locales/locale_en.yml
@@ -28,7 +28,7 @@ en:
         
         event_deleted_notification: "Event '%{title}' has been deleted."
         event_updated_notification: "Event '%{title}' has been updated."
-        event_created_notification: "Event '%{title}' has been created."
+        event_created_notification: "Event '%{title}' has been created by %{name}."
         
         event_updated_change: "%{title} updated."
         event_deleted_change: "%{title} deleted."

--- a/plugins/idle/commands/idle_execute_cmd.rb
+++ b/plugins/idle/commands/idle_execute_cmd.rb
@@ -17,7 +17,7 @@ module AresMUSH
       def handle
         report = []
         
-        Manage.announce t('idle.idle_sweep_beginning')
+        # Manage.announce t('idle.idle_sweep_beginning')
         client.program[:idle_queue].map { |id, action| action }.uniq.each do |action|
           ids =  client.program[:idle_queue].select { |id, a| a == action }
           chars = ids.map { |id, action| Character[id] }
@@ -73,7 +73,7 @@ module AresMUSH
           t('idle.idle_post_subject'), 
           t('idle.idle_post_body', :report => report.join("%R")))
         
-          Manage.announce t('idle.idle_sweep_finished')
+        # Manage.announce t('idle.idle_sweep_finished')
       end      
     end
   end

--- a/plugins/idle/helpers.rb
+++ b/plugins/idle/helpers.rb
@@ -16,6 +16,10 @@ module AresMUSH
       ClassTargetFinder.with_a_character(name, client, enactor) do |model|
         Idle.add_to_roster(model, contact)
         client.emit_success t('idle.roster_updated')
+        Forum.system_post(
+          Global.read_config("idle", "idle_category"), 
+          t('idle.roster_opened_subject', :name => model.name), 
+          t('idle.roster_opened_body', :name => model.name))
       end
     end
     
@@ -24,6 +28,8 @@ module AresMUSH
       char.update(idle_state: "Roster")
       char.update(roster_played: char.is_approved?)  # Assume played if approved.
       Idle.idle_cleanup(char, "Roster")
+      Roles.remove_role(char, "approved")
+      Chargen.unsubmit_app(char)
     end
     
     def self.remove_from_roster(char)

--- a/plugins/idle/locales/locale_en.yml
+++ b/plugins/idle/locales/locale_en.yml
@@ -18,7 +18,9 @@ en:
         previously_warned: "Previously idle warned."
         idle_post_subject: "Idled-Out Characters"
         idle_post_body: "The following characters have idled out or are in danger of doing so.%{report}"
-        not_eligible_for_idle: "This command can't be used on NPCs, roster characters and chracters exempt from the idle purge."
+        roster_opened_subject: "Rostered: %{name}"
+        roster_opened_body: "%{name} has been rostered and is now available for applications."
+        not_eligible_for_idle: "This command can't be used on NPCs, roster characters and characters exempt from the idle purge."
         idle_preview: "%{name} last on %{last_on}.  Status: %{status}. Suggested idle action: %{idle_action}.  Last will: %{lastwill}"
         
         lastwill_set: "Last will instructions set."

--- a/plugins/roles/commands/roles_cmd.rb
+++ b/plugins/roles/commands/roles_cmd.rb
@@ -8,6 +8,11 @@ module AresMUSH
       def parse_args
         self.name = !cmd.args ? enactor_name : trim_arg(cmd.args)
       end
+
+      def check_can_use
+        return t('dispatcher.not_allowed') if !enactor.is_admin?
+        return nil
+      end
       
       def handle        
         ClassTargetFinder.with_a_character(self.name, client, enactor) do |char|


### PR DESCRIPTION
…ovements to idle and roster announcements.

* Roles command is now only usable by admin. Do not permit characters to view the list of roles.
* When an event is created, send a wall announcement instead of a Game channel message. Add the Event creator's name to the message. Other event messages remain on Game.
* Remove wall announcements involved in the idle sweep process, since a bbpost is already made.
* Post to the idle_category forum board when a character is rostered with roster/add.
* Remove the approved role and unsubmit the app of a character, when they are rostered with roster/add. This is to leave the character in a chargennable state for the next player.