### PR TITLE
Adjust parameters for 'save fields from profile edit' function

### DIFF
--- a/plugins/profile/web/profile_save_request_handler.rb
+++ b/plugins/profile/web/profile_save_request_handler.rb
@@ -73,7 +73,7 @@ module AresMUSH
         
         Describe.save_web_descs(char, request.args['descs'])
 
-        errors = CustomCharFields.save_fields_from_profile_edit(char, request.args) || []
+        errors = CustomCharFields.save_fields_from_profile_edit(char, request.args, enactor) || []
         if (errors.class == Array && errors.any?)
           return { error: errors.join("\n") }
         end


### PR DESCRIPTION
Addition of the Admin tab in the character profile edit necessitated redoing the custom powers/skills/resources/drawbacks tabs.
Edit boxes for these were all moved onto the Admin tab, where Edit Background was also moved.
Needed to add 'enactor' parameter to save_fields_from_profile_edit function call to match custom_char_fields.rb, where enactor is passed as a parameter to the function definition for an is_admin check. This may not be necessary? Review when not tired.